### PR TITLE
Print error message if gun module is not installed

### DIFF
--- a/test/panic/load.js
+++ b/test/panic/load.js
@@ -86,7 +86,7 @@ describe("Load test "+ config.browsers +" browser(s) across "+ config.servers +"
 					res.end("I am "+ env.i +"!");
 				});
 				// Launch the server and start gun!
-				var Gun = require('gun');
+				try{ var Gun = require('gun'); }catch(e){ console.error(e) }
 				// Attach the server to gun.
 				var gun = Gun({file: env.i+'data', web: server, localStorage: false});
 				server.listen(env.config.port + env.i, function(){


### PR DESCRIPTION
I'm new the the PANIC test suite, and it wasn't obvious to me initially that an external (not included in the git repo) copy of Gun is being used. I didn't realize that an `npm install gun` was required before the test would work. However, the test would simply fail silently and I didn't know why. After debugging with console.log, I discovered the reason: `Error: Cannot find module 'gun'`. Printing the error would have saved me time, so that's all this pull-request does, print the error I would have liked to have received.